### PR TITLE
Update luadraw-doc2d-section-3-Constructions-géométriques.tex

### DIFF
--- a/doc/luadraw/body-fr/luadraw-doc2d-section-3-Constructions-géométriques.tex
+++ b/doc/luadraw/body-fr/luadraw-doc2d-section-3-Constructions-géométriques.tex
@@ -5,8 +5,8 @@ Dans cette section sont regroupées les fonctions construisant des figures géom
 \subsection{circumcircle(), incircle()}
 
 \begin{itemize}
-    \item La fonction \textbf{circumcircle(a,b,c)} (ou \textbf{circumcircle(\{a,b,c\})}) , où $a$, $b$ et $c$ sont trois points (trois nombres complexes), renvoie le cercle circonscrit au triangle formé par ces trois points, sous la forme d'une séquence: $C,r$, où $C$ est le centre du cercle (nombre complexe), $r$ son rayon.
-    \item La fonction \textbf{incircle3d(a,b,c)} (ou \textbf{incircle3d(\{a,b,c\})}) , où $a$, $b$ et $c$ sont trois points (trois nombres complexes), renvoie le cercle inscrit dans triangle formé par ces trois points, sous la forme d'une séquence: $C,r$, où $C$ est le centre du cercle (nombre complexe), $r$ son rayon.    
+    \item La fonction \textbf{circumcircle(a,b,c)} (ou \textbf{circumcircle(\{a,b,c\})}), où $a$, $b$ et $c$ sont trois points (trois nombres complexes), renvoie le cercle circonscrit au triangle formé par ces trois points, sous la forme d'une séquence: $C,r$, où $C$ est le centre du cercle (nombre complexe), $r$ son rayon.
+    \item La fonction \textbf{incircle3d(a,b,c)} (ou \textbf{incircle3d(\{a,b,c\})}), où $a$, $b$ et $c$ sont trois points (trois nombres complexes), renvoie le cercle inscrit dans triangle formé par ces trois points, sous la forme d'une séquence: $C,r$, où $C$ est le centre du cercle (nombre complexe), $r$ son rayon.    
 \end{itemize}
 
 \subsection{cvx\_hull2d()}


### PR DESCRIPTION
Supression d'espaces. Cependant comme ces espaces semblent avoir été placés ici explicitement, je fais un pull request spécifique, la possibilité pour ce pull request de ne pas être accepté étant élevée. J'ignore si ces espaces sont là pour éviter un dépassement dans la marge, ou pour aérer, mais normalement il n'y a pas espace avant une virgule.

<img width="745" height="73" alt="image" src="https://github.com/user-attachments/assets/a665f7d5-101b-4da8-a48d-a71e44469b90" />
