### PR TITLE
add methods to plot fileds on the surface

### DIFF
--- a/files/extensions/luadraw_fields.lua
+++ b/files/extensions/luadraw_fields.lua
@@ -82,3 +82,42 @@ function graph:DplotXY(X,Y,draw_options)
     end
     self:Dpolyline(L,draw_options)
 end
+
+
+function ld.surfacefield(p, f, x1, x2, y1, y2, grid, long)
+    if grid == nil then grid = {25,25} end
+    local deltax, deltay = (x2-x1)/(grid[1]-1), (y2-y1)/(grid[2]-1)
+    if long == nil then long = math.min(deltax,deltay) end
+    local h = 1e-5
+    local vectors = {}
+
+    for i = 0, grid[1]-1 do
+        x = x1 + i*deltax
+        for j = 0, grid[2]-1 do
+            y = y1 + j*deltay
+            local P = p(x, y)
+            local A = f(x, y)
+            local px = (p(x+h, y) - p(x-h, y))/(2*h)
+            local py = (p(x, y+h) - p(x, y-h))/(2*h)
+            v = pt3d.normalize(A[1]*px + A[2]*py)
+            if v ~= nil then
+                table.insert(vectors, {P-long/2*v, P+long/2*v})
+            end
+        end
+    end
+    return vectors
+end
+
+function graph3d:Dsurfacefield(p, f, args)
+    args = args or {}
+    local window3d = args.window3d or self.param.viewport3d
+    local vectors = ld.surfacefield(
+        p, f,
+        window3d[1], window3d[2], window3d[3], window3d[4],
+        args.grid,
+        args.length
+    )
+    local clip = args.clip
+    if clip == nil then clip = true end
+    self:Dpolyline3d(vectors, false, args.draw_options, clip)
+end


### PR DESCRIPTION
The reason for the PR is to [explore this question](https://tex.stackexchange.com/q/691984/322482).

By Learning from the code:

https://github.com/pfradin/luadraw/blob/120576d4f923b4843841bb2ce87ccca85549f5db/files/extensions/luadraw_fields.lua#L17-L52

---

Noted that this line, the `local x, y, v = x1` has extra `y` and `v`(really?).

https://github.com/pfradin/luadraw/blob/120576d4f923b4843841bb2ce87ccca85549f5db/files/extensions/luadraw_fields.lua#L26

Here below is my complete code, but, I was not sure how to mimic the region border clip:

```tex
% https://tex.stackexchange.com/q/691984/322482
\documentclass{standalone}
\usepackage[3d]{luadraw}
\usepackage[svgnames]{xcolor}
\usepackage{fourier-otf}
\begin{document}

    \begin{luadraw}{name=surface-quiver}
        local ld = luadraw
        local pt3d = ld.pt3d
        local graph3d = ld.graph3d
        local M = pt3d.M
        local sin, cos, pi, sqrt = math.sin, math.cos, math.pi, math.sqrt

        function ld.surfacefield(p, f, x1, x2, y1, y2, grid, long)
            if grid == nil then grid = {25,25} end
            local deltax, deltay = (x2-x1)/(grid[1]-1), (y2-y1)/(grid[2]-1)
            if long == nil then long = math.min(deltax,deltay) end
            local h = 1e-5
            local vectors = {}

            for i = 0, grid[1]-1 do
                x = x1 + i*deltax
                for j = 0, grid[2]-1 do
                    y = y1 + j*deltay
                    local P = p(x, y)
                    local A = f(x, y)
                    local px = (p(x+h, y) - p(x-h, y))/(2*h)
                    local py = (p(x, y+h) - p(x, y-h))/(2*h)
                    v = pt3d.normalize(A[1]*px + A[2]*py)
                    if v ~= nil then
                        table.insert(vectors, {P-long/2*v, P+long/2*v})
                    end
                end
            end
            return vectors
        end

        function graph3d:Dsurfacefield(p, f, args)
            args = args or {}
            local window3d = args.window3d or self.param.viewport3d
            local vectors = ld.surfacefield(
                p, f,
                window3d[1], window3d[2], window3d[3], window3d[4],
                args.grid,
                args.length
            )
            local clip = args.clip
            if clip == nil then clip = true end
            self:Dpolyline3d(vectors, false, args.draw_options, clip)
        end


        local surface = function(x, y)
            return M(x, y, 0.15*x^2 - 0.15*y^2)
        end
        local field = function(x, y)
            return {sin(y), sin(x)}
        end

        local g = ld.graph3d:new{
            window3d={-4.5, 4.5, -4.5, 4.5, -2.7, 2.7},
            window={-7.5, 7.5, -6, 4},
            viewdir={65, 35},size={10, 10},
        }

        local x1, x2, y1, y2 = -4, 4, -4, 4
        local S = ld.surface(surface, x1, x2, y1, y2)
        g:Dfacet(S, {mode=ld.mShadedOnly, usepalette = {ld.palRainbow,"z"}})

        g:Dsurfacefield(surface, field, {
            window3d={x1, x2, y1, y2, g.param.viewport3d[5], g.param.viewport3d[6]},
            grid={10, 10},
            length=1,draw_options="-Stealth,Navy"
        })

        g:Dlabel("$z=0.15x^2-0.15y^2$,\\quad $F(x,y)=(\\sin y,\\sin x)$", ld.cpx.Z(0, -5.25), {pos="S"})
        g:Show()
    \end{luadraw}

\end{document}
```

<img width="1238" height="958" alt="PixPin-2026-06-03_01-42-18" src="https://github.com/user-attachments/assets/193dbacf-3050-4f54-8d36-52620a4cc034" />

I would be appreciated you for any review and suggestions. Thanks!